### PR TITLE
feat: add some DurableObject's custom field handler

### DIFF
--- a/.changeset/three-actors-develop.md
+++ b/.changeset/three-actors-develop.md
@@ -1,0 +1,36 @@
+---
+"hono-do": minor
+---
+
+Support for three handlers about [Hibernation Websocket API](https://developers.cloudflare.com/durable-objects/learning/websockets/#websocket-hibernation).
+
+- `webSocketMessage` handler
+- `webSocketClose` handler
+- `webSocketError` handler
+
+You can use these handlers same way as `alarm` handler in Hono DO.
+
+## Usage
+
+### Flat way
+
+```ts
+const DO = generateHonoObject("/", () => {});
+DO.alarm(async () => {});
+DO.webSocketMessage(async () => {});
+DO.webSocketClose(async () => {});
+DO.webSocketError(async () => {});
+```
+
+### Chaining way
+
+```ts
+generateHonoObject("/", () => {})
+    .alarm(async () => {})
+    .webSocketMessage(async () => {})
+    .webSocketClose(async () => {})
+    .webSocketError(async () => {});
+```
+
+Take care for registering multiple handlers for same event.
+If you register so, you will get an error.

--- a/packages/hono-do/src/error.ts
+++ b/packages/hono-do/src/error.ts
@@ -1,0 +1,11 @@
+export class HonoDOError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HonoDOError";
+  }
+}
+
+export const Errors = {
+  handlerAlreadySet: (handlerName: string) =>
+    new HonoDOError(`Handler ${handlerName} already set`),
+};

--- a/packages/hono-do/src/index.ts
+++ b/packages/hono-do/src/index.ts
@@ -1,16 +1,15 @@
 import { Env, Hono, Schema } from "hono";
 
-export interface HonoObjectVars {}
-
-interface HonoObject<
-  E extends Env = Env,
-  S extends Schema = Record<string, never>,
-  BasePath extends string = "/",
-> {
-  app: Hono<E, S, BasePath>;
-  state: DurableObjectState;
-  vars: HonoObjectVars;
-}
+import { HonoDOError, Errors } from "./error";
+import {
+  AlarmHandler,
+  WebSocketMessageHandler,
+  WebSocketCloseHandler,
+  WebSocketErrorHandler,
+  HonoObjectHandlers,
+  HonoObjectVars,
+  HonoObject,
+} from "./types";
 
 export function generateHonoObject<
   E extends Env = Env,
@@ -23,52 +22,92 @@ export function generateHonoObject<
     state: DurableObjectState,
     vars: HonoObjectVars,
   ) => void | Promise<void>,
-  alarm?: (
-    state: DurableObjectState,
-    vars: HonoObjectVars,
-  ) => void | Promise<void>,
+  handlers: HonoObjectHandlers = {},
 ) {
-  const honoObject = function (
-    this: HonoObject<E, S, BasePath>,
-    state: DurableObjectState,
-  ) {
-    const app = new Hono<E, S, BasePath>().basePath(basePath);
+  const _handlers: HonoObjectHandlers = {
+    ...handlers,
+  };
+
+  const app = new Hono<E, S, BasePath>().basePath(basePath);
+
+  const honoObject = function (this, state) {
     this.app = app;
     this.state = state;
     this.vars = {};
     state.blockConcurrencyWhile(async () => {
       await cb(app, state, this.vars);
     });
-  };
+  } as HonoObject<E, S, BasePath>;
 
   honoObject.prototype.fetch = function (
     this: HonoObject<E, S, BasePath>,
-    request: Request,
+    ...args: Parameters<NonNullable<DurableObject["fetch"]>>
   ) {
-    return this.app.fetch(request);
+    return this.app.fetch(...args);
   };
 
-  if (alarm !== undefined) {
-    honoObject.prototype.alarm = async function (
-      this: HonoObject<E, S, BasePath>,
-    ) {
-      await alarm(this.state, this.vars);
-    };
-  } else {
-    honoObject.alarm = function (
-      cb: (
-        state: DurableObjectState,
-        vars: HonoObjectVars,
-      ) => void | Promise<void>,
-    ) {
-      honoObject.prototype.alarm = async function (
-        this: HonoObject<E, S, BasePath>,
-      ) {
-        await cb(this.state, this.vars);
-      };
-      return honoObject;
-    };
-  }
+  honoObject.prototype.alarm = async function (
+    this: HonoObject<E, S, BasePath>,
+  ) {
+    await _handlers.alarm?.(this.state, this.vars);
+  };
+
+  honoObject.prototype.webSocketMessage = function (
+    this: HonoObject<E, S, BasePath>,
+    ...args: Parameters<NonNullable<DurableObject["webSocketMessage"]>>
+  ) {
+    _handlers.webSocketMessage?.(...args, this.state, this.vars);
+  };
+
+  honoObject.prototype.webSocketClose = function (
+    this: HonoObject<E, S, BasePath>,
+    ...args: Parameters<NonNullable<DurableObject["webSocketClose"]>>
+  ) {
+    _handlers.webSocketClose?.(...args, this.state, this.vars);
+  };
+
+  honoObject.prototype.webSocketError = function (
+    this: HonoObject<E, S, BasePath>,
+    ...args: Parameters<NonNullable<DurableObject["webSocketError"]>>
+  ) {
+    _handlers.webSocketError?.(...args, this.state, this.vars);
+  };
+
+  const isCalledMap = new Map<string, boolean>();
+
+  honoObject.alarm = function (handler: AlarmHandler) {
+    const name = "alarm";
+    if (isCalledMap.get(name)) throw Errors.handlerAlreadySet(name);
+    _handlers.alarm = handler;
+    isCalledMap.set(name, true);
+    return honoObject;
+  };
+
+  honoObject.webSocketMessage = function (handler: WebSocketMessageHandler) {
+    const name = "webSocketMessage";
+    if (isCalledMap.get(name)) throw Errors.handlerAlreadySet(name);
+    _handlers.webSocketMessage = handler;
+    isCalledMap.set(name, true);
+    return honoObject;
+  };
+
+  honoObject.webSocketClose = function (handler: WebSocketCloseHandler) {
+    const name = "webSocketClose";
+    if (isCalledMap.get(name)) throw Errors.handlerAlreadySet(name);
+    _handlers.webSocketClose = handler;
+    isCalledMap.set(name, true);
+    return honoObject;
+  };
+
+  honoObject.webSocketError = function (handler: WebSocketErrorHandler) {
+    const name = "webSocketError";
+    if (isCalledMap.get(name)) throw Errors.handlerAlreadySet(name);
+    _handlers.webSocketError = handler;
+    isCalledMap.set(name, true);
+    return honoObject;
+  };
 
   return honoObject;
 }
+
+export { HonoObjectVars, HonoDOError };

--- a/packages/hono-do/src/types.ts
+++ b/packages/hono-do/src/types.ts
@@ -1,0 +1,68 @@
+import { Env, Hono, Schema } from "hono";
+
+import { MergeArray } from "./utils";
+
+export interface HonoObjectVars {}
+
+interface HonoObjectState<
+  E extends Env = Env,
+  S extends Schema = Record<string, never>,
+  BasePath extends string = "/",
+> {
+  app: Hono<E, S, BasePath>;
+  state: DurableObjectState;
+  vars: HonoObjectVars;
+}
+
+export interface HonoObject<
+  E extends Env = Env,
+  S extends Schema = Record<string, never>,
+  BasePath extends string = "/",
+> extends HonoObjectState<E, S, BasePath> {
+  (this: HonoObject<E, S, BasePath>, state: DurableObjectState): void;
+  alarm: (handler: AlarmHandler) => HonoObject<E, S, BasePath>;
+  webSocketMessage: (
+    handler: WebSocketMessageHandler,
+  ) => HonoObject<E, S, BasePath>;
+  webSocketClose: (
+    handler: WebSocketCloseHandler,
+  ) => HonoObject<E, S, BasePath>;
+  webSocketError: (
+    handler: WebSocketErrorHandler,
+  ) => HonoObject<E, S, BasePath>;
+}
+
+export type AlarmHandler = (
+  ...args: MergeArray<
+    Parameters<NonNullable<DurableObject["alarm"]>>,
+    [state: DurableObjectState, vars: HonoObjectVars]
+  >
+) => ReturnType<NonNullable<DurableObject["alarm"]>>;
+
+export type WebSocketMessageHandler = (
+  ...args: MergeArray<
+    Parameters<NonNullable<DurableObject["webSocketMessage"]>>,
+    [state: DurableObjectState, vars: HonoObjectVars]
+  >
+) => ReturnType<NonNullable<DurableObject["webSocketMessage"]>>;
+
+export type WebSocketCloseHandler = (
+  ...args: MergeArray<
+    Parameters<NonNullable<DurableObject["webSocketClose"]>>,
+    [state: DurableObjectState, vars: HonoObjectVars]
+  >
+) => ReturnType<NonNullable<DurableObject["webSocketClose"]>>;
+
+export type WebSocketErrorHandler = (
+  ...args: MergeArray<
+    Parameters<NonNullable<DurableObject["webSocketError"]>>,
+    [state: DurableObjectState, vars: HonoObjectVars]
+  >
+) => ReturnType<NonNullable<DurableObject["webSocketError"]>>;
+
+export interface HonoObjectHandlers {
+  alarm?: AlarmHandler;
+  webSocketMessage?: WebSocketMessageHandler;
+  webSocketClose?: WebSocketCloseHandler;
+  webSocketError?: WebSocketErrorHandler;
+}

--- a/packages/hono-do/src/utils.ts
+++ b/packages/hono-do/src/utils.ts
@@ -1,0 +1,6 @@
+export type MergeArray<T extends unknown[], U extends unknown[]> = [
+  ...T,
+  ...U,
+] extends [...infer R]
+  ? R
+  : never;

--- a/packages/hono-do/tests/fixtures/alarm/index.ts
+++ b/packages/hono-do/tests/fixtures/alarm/index.ts
@@ -2,12 +2,6 @@ import { Hono } from "hono";
 
 import { generateHonoObject } from "../../../src";
 
-declare module "../../../src" {
-  interface HonoObjectVars {
-    message: string;
-  }
-}
-
 const app = new Hono<{
   Bindings: {
     ALARM: DurableObjectNamespace;
@@ -33,10 +27,24 @@ export const Alarm = generateHonoObject(
     });
 
     app.get("/", async (c) => {
+      // NOTE:
+      // ```ts
+      // declare module "hono-do" {
+      //   interface HonoObjectVars {
+      //     message: string;
+      //   }
+      // }
+      // ```
+      //
+      // This will resolve the type error, but this code effects other files. so I don't use this.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
       return c.text(vars.message);
     });
   },
 ).alarm(async (state, vars) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
   vars.message = "Hello, Hono DO!";
 });
 

--- a/packages/hono-do/tests/fixtures/alarm/wrangler.toml
+++ b/packages/hono-do/tests/fixtures/alarm/wrangler.toml
@@ -1,0 +1,9 @@
+name = "hono-do-test"
+compatibility_date = "2023-01-01"
+
+[durable_objects]
+bindings = [{ name = "ALARM", class_name = "Alarm" }]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["Alarm"]

--- a/packages/hono-do/tests/index.test.ts
+++ b/packages/hono-do/tests/index.test.ts
@@ -72,4 +72,31 @@ describe("Worker", () => {
       expect(await resp.text()).toBe("1");
     });
   });
+
+  describe("Alarm", () => {
+    let worker: UnstableDevWorker;
+
+    beforeEach(async () => {
+      worker = await unstable_dev(join(__dirname, "fixtures/alarm/index.ts"), {
+        experimental: { disableExperimentalWarning: true },
+      });
+    });
+
+    afterEach(async () => {
+      await worker.stop();
+    });
+
+    it("should work alarm handler", async () => {
+      const resp = await worker.fetch("/alarm", { method: "POST" });
+      expect(resp.status).toBe(200);
+      expect(await resp.json()).toStrictEqual({ queued: true });
+
+      // alarm set "Hello, Hono DO!" to vars.message after 100ms
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      const resp2 = await worker.fetch("/alarm");
+      expect(resp2.status).toBe(200);
+      expect(await resp2.text()).toBe("Hello, Hono DO!");
+    });
+  });
 });

--- a/packages/hono-do/tests/index.test.ts
+++ b/packages/hono-do/tests/index.test.ts
@@ -27,6 +27,22 @@ describe("generateHonoObject", () => {
       });
     });
   });
+
+  it("should work with handler chain by flat way", async () => {
+    const DO = generateHonoObject("/", () => {});
+    DO.alarm(async () => {});
+    DO.webSocketMessage(async () => {});
+    DO.webSocketClose(async () => {});
+    DO.webSocketError(async () => {});
+  });
+
+  it("should work with handler chain by chain way", async () => {
+    generateHonoObject("/", () => {})
+      .alarm(async () => {})
+      .webSocketMessage(async () => {})
+      .webSocketClose(async () => {})
+      .webSocketError(async () => {});
+  });
 });
 
 describe("Worker", () => {

--- a/packages/hono-do/tests/index.test.ts
+++ b/packages/hono-do/tests/index.test.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { unstable_dev } from "wrangler";
 
 import { generateHonoObject } from "../src";
+import { Errors } from "../src/error";
 
 import type { UnstableDevWorker } from "wrangler";
 
@@ -51,6 +52,17 @@ describe("generateHonoObject", () => {
       .webSocketMessage(async () => {})
       .webSocketClose(async () => {})
       .webSocketError(async () => {});
+  });
+
+  it("should error when multiple handler set to same Hono Object", async () => {
+    const DO = generateHonoObject("/", () => {});
+    DO.webSocketMessage(async () => {});
+    expect(() => DO.alarm(async () => {})).not.toThrowError(
+      Errors.handlerAlreadySet("alarm"),
+    );
+    expect(() => DO.webSocketMessage(async () => {})).toThrowError(
+      Errors.handlerAlreadySet("webSocketMessage"),
+    );
   });
 });
 

--- a/packages/hono-do/tests/index.test.ts
+++ b/packages/hono-do/tests/index.test.ts
@@ -28,6 +28,15 @@ describe("generateHonoObject", () => {
     });
   });
 
+  it("should work with type-safe base path", async () => {
+    generateHonoObject("/:hogeId", (app) => {
+      app.get("/:fugaId", async (c) => {
+        expectTypeOf(c.req.param("hogeId")).toEqualTypeOf<string>();
+        expectTypeOf(c.req.param("hogeId")).toEqualTypeOf<string>();
+      });
+    });
+  });
+
   it("should work with handler chain by flat way", async () => {
     const DO = generateHonoObject("/", () => {});
     DO.alarm(async () => {});

--- a/packages/hono-do/tests/utils.test.ts
+++ b/packages/hono-do/tests/utils.test.ts
@@ -1,0 +1,18 @@
+import { MergeArray } from "../src/utils";
+
+describe("MergeArray", () => {
+  it("should work", () => {
+    expectTypeOf<MergeArray<[1, 2], [3, 4]>>().toEqualTypeOf<[1, 2, 3, 4]>();
+  });
+
+  it("should work with empty array", () => {
+    expectTypeOf<MergeArray<[], [3, 4]>>().toEqualTypeOf<[3, 4]>();
+    expectTypeOf<MergeArray<[1, 2], []>>().toEqualTypeOf<[1, 2]>();
+  });
+
+  it("should work with tuple", () => {
+    expectTypeOf<MergeArray<[a: 1, b: 2], [c: 3, d: 4]>>().toEqualTypeOf<
+      [a: 1, b: 2, c: 3, d: 4]
+    >();
+  });
+});


### PR DESCRIPTION
For [Hibernatable WebSockets API](https://developers.cloudflare.com/durable-objects/api/websockets/) support, extend some fields.

- webSocketMessage
- webSocketClose
- webSocketError

Optional:

- refactoring some
- introducte Hono DO custom error for DX
- handler duplicate registoration check